### PR TITLE
chore: added two additional endpoints

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,14 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToOne, OneToOne, JoinColumn, PrimaryColumn, Generated } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  ManyToOne,
+  OneToOne,
+  JoinColumn,
+  PrimaryColumn,
+  Generated,
+} from 'typeorm';
 
 @Entity()
 export class CricketTeam {
@@ -23,45 +33,45 @@ export class CricketTeam {
 
 @Entity()
 export class CricketPlayer {
-    @PrimaryColumn()
-    id: string;
+  @PrimaryColumn()
+  id: string;
 
-    @Column()
-    teamId: string;
+  @Column()
+  teamId: string;
 
-    @Column()
-    firstName: string;
+  @Column()
+  firstName: string;
 
-    @Column()
-    lastName: string;
+  @Column()
+  lastName: string;
 
-    @Column()
-    position: string;
+  @Column()
+  position: string;
 
-    @ManyToOne(() => CricketTeam, team => team.players)
-    @JoinColumn({ name: 'teamId' })
-    team: CricketTeam;
+  @ManyToOne(() => CricketTeam, team => team.players)
+  @JoinColumn({ name: 'teamId' })
+  team: CricketTeam;
 
-    @Column()
-    image_path: string;
+  @Column()
+  image_path: string;
 
-    @OneToMany(() => PlayerPerformance, performance => performance.player)
-    performances: PlayerPerformance[];
+  @OneToMany(() => PlayerPerformance, performance => performance.player)
+  performances: PlayerPerformance[];
 
-    constructor(
-        id: string,
-        teamId: string,
-        firstName: string,
-        lastName: string,
-        position: string,
-        image_path: string
-    ) {
-        this.id = id;
-        this.teamId = teamId;
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.position = position;
-        this.image_path=image_path
+  constructor(
+    id: string,
+    teamId: string,
+    firstName: string,
+    lastName: string,
+    position: string,
+    image_path: string
+  ) {
+    this.id = id;
+    this.teamId = teamId;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.position = position;
+    this.image_path=image_path
     }
 }
 

--- a/src/sports/modules/player/controllers/player.controller.ts
+++ b/src/sports/modules/player/controllers/player.controller.ts
@@ -1,30 +1,39 @@
 import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
 import { CricketPlayerService } from '../service/player.service';
-import { CricketPlayer } from "src/schema";
-
+import { CricketPlayer } from 'src/schema';
+import { PlayerStats, PlayerRadarStats } from 'src/types/player.types';
 
 @Controller('cricket-player')
-export class CricketPlayerController{
-    constructor (private readonly playerService: CricketPlayerService){}
+export class CricketPlayerController {
+  constructor(private readonly playerService: CricketPlayerService) {}
 
-@Post()
-create (@Body() dto: CricketPlayer){
+  @Post()
+  create(@Body() dto: CricketPlayer): Promise<CricketPlayer> {
     return this.playerService.create(dto);
-}
+  }
 
-@Get()
-findAll(){
+  @Get()
+  findAll(): Promise<CricketPlayer[]> {
     return this.playerService.findAll();
-}
+  }
 
-@Get (':id')
-findOne(@Param ('id') id:string){
+  @Get('stats')
+  getPlayerStats(): Promise<PlayerStats[]> {
+    return this.playerService.getPlayerStats();
+  }
+
+  @Get('radar/:id')
+  getPlayerRadarStats(@Param('id') id: string): Promise<PlayerRadarStats> {
+    return this.playerService.getPlayerRadarStats(id);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<CricketPlayer> {
     return this.playerService.findOne(id);
-}
+  }
 
-@Delete (':id')
-delete (@Param('id') id:string){
-return this.playerService.delete(id);
+  @Delete(':id')
+  delete(@Param('id') id: string): Promise<void> {
+    return this.playerService.delete(id);
+  }
 }
-}
-

--- a/src/sports/modules/player/player.module.ts
+++ b/src/sports/modules/player/player.module.ts
@@ -1,14 +1,28 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CricketPlayer } from "src/schema";
+import {
+  CricketPlayer,
+  CricketTeam,
+  CricketMatch,
+  PlayerPerformance,
+  CricketPlayerHistorial,
+} from 'src/schema';
 import { CricketPlayerController } from './controllers/player.controller';
 import { CricketPlayerRepository } from './repository/player.repository';
 import { CricketPlayerService } from './service/player.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CricketPlayer])],
+  imports: [
+    TypeOrmModule.forFeature([
+      CricketPlayer,
+      CricketTeam,
+      CricketMatch,
+      PlayerPerformance,
+      CricketPlayerHistorial,
+    ]),
+  ],
   controllers: [CricketPlayerController],
   providers: [CricketPlayerRepository, CricketPlayerService],
-  exports: [CricketPlayerService], 
+  exports: [CricketPlayerService],
 })
 export class CricketPlayerModule {}

--- a/src/sports/modules/player/repository/player.repository.ts
+++ b/src/sports/modules/player/repository/player.repository.ts
@@ -1,32 +1,93 @@
 import { Injectable, ConflictException } from "@nestjs/common";
 import { Repository } from "typeorm";
 import { InjectRepository } from '@nestjs/typeorm';
-import { CricketPlayer } from "src/schema";
+import {
+  CricketPlayer,
+  CricketTeam,
+  CricketMatch,
+  PlayerPerformance,
+  CricketPlayerHistorial,
+} from 'src/schema';
 
 @Injectable()
-export class CricketPlayerRepository{
-     constructor(
-        @InjectRepository(CricketPlayer)
-        private readonly repo: Repository<CricketPlayer>,
-     ) {}
+export class CricketPlayerRepository {
+  constructor(
+    @InjectRepository(CricketPlayer)
+    private readonly playerRepo: Repository<CricketPlayer>,
+    @InjectRepository(CricketTeam)
+    private readonly teamRepo: Repository<CricketTeam>,
+    @InjectRepository(CricketMatch)
+    private readonly matchRepo: Repository<CricketMatch>,
+    @InjectRepository(PlayerPerformance)
+    private readonly performanceRepo: Repository<PlayerPerformance>,
+    @InjectRepository(CricketPlayerHistorial)
+    private readonly historyRepo: Repository<CricketPlayerHistorial>,
+  ) {}
 
   async create(player: CricketPlayer) {
-    const existing = await this.repo.findOne({ where: { id: player.id } });
+    const existing = await this.playerRepo.findOne({
+      where: { id: player.id },
+    });
     if (existing) {
       throw new ConflictException('The player ID already exists');
     }
-
-    return this.repo.save(player);
+    return this.playerRepo.save(player);
   }
 
+  findAll() {
+    return this.playerRepo.find();
+  }
 
-     findAll (){
-        return this.repo.find();
-     }
-     delete (id: string){
-      return this.repo.delete(id);
-     }
-     findOne(id: string){
-        return this.repo.findOne({where: {id}});
-     }
+  delete(id: string) {
+    return this.playerRepo.delete(id);
+  }
+
+  findOne(id: string) {
+    return this.playerRepo.findOne({ where: { id } });
+  }
+
+  async findTeamById(teamId: string) {
+    try {
+      const team = await this.teamRepo.findOne({ where: { id: teamId } });
+      return team;
+    } catch (error) {
+      console.error(`Error fetching team for teamId ${teamId}:`, error);
+      return null;
+    }
+  }
+
+  async getTotalMatches() {
+    try {
+      const count = await this.matchRepo.count();
+      return count;
+    } catch (error) {
+      console.error('Error fetching total matches:', error);
+      return 0;
+    }
+  }
+
+  async getPlayerPerformances(playerId: string) {
+    try {
+      const performances = await this.performanceRepo.find({
+        where: { cricketPlayerId: playerId },
+      });
+      return performances;
+    } catch (error) {
+      console.error(
+        `Error fetching performances for player ${playerId}:`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  async getPlayerHistory(playerId: string) {
+    try {
+      const history = await this.historyRepo.find({ where: { playerId } });
+      return history;
+    } catch (error) {
+      console.error(`Error fetching history for player ${playerId}:`, error);
+      return [];
+    }
+  }
 }

--- a/src/sports/modules/player/service/player.service.ts
+++ b/src/sports/modules/player/service/player.service.ts
@@ -1,15 +1,27 @@
-import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CricketPlayerRepository } from '../repository/player.repository';
 import { CricketPlayer } from 'src/schema';
+import { PlayerStats, PlayerRadarStats } from 'src/types/player.types';
 
 @Injectable()
 export class CricketPlayerService {
-  constructor(private readonly teamRepo: CricketPlayerRepository) {}
+  constructor(private readonly repo: CricketPlayerRepository) {}
 
-  async create(entity: CricketPlayer) {
-    const team = new CricketPlayer(entity.id,entity.teamId, entity.firstName,entity.lastName,entity.position,entity.image_path);
+  async create(entity: CricketPlayer): Promise<CricketPlayer> {
+    const playerToCreate = new CricketPlayer(
+      entity?.id,
+      entity?.teamId,
+      entity?.firstName,
+      entity?.lastName,
+      entity?.position,
+      entity?.image_path,
+    );
     try {
-      return await this.teamRepo.create(team);
+      return await this.repo.create(playerToCreate);
     } catch (error) {
       if (error.code === '23505' || error.number === 2627) {
         throw new ConflictException('The player ID already exists');
@@ -18,23 +30,134 @@ export class CricketPlayerService {
     }
   }
 
-  findAll() {
-    return this.teamRepo.findAll();
+  findAll(): Promise<CricketPlayer[]> {
+    return this.repo.findAll();
   }
 
-  async findOne(id: string) {
-    const team = await this.teamRepo.findOne(id);
-    if (!team) {
+  async findOne(id: string): Promise<CricketPlayer> {
+    const player = await this.repo.findOne(id);
+    if (!player) {
       throw new NotFoundException('Player not found');
     }
-    return team;
+    return player;
   }
 
   async delete(id: string): Promise<void> {
-    const team = await this.teamRepo.findOne(id);
-    if (!team) {
+    const player = await this.repo.findOne(id);
+    if (!player) {
       throw new NotFoundException('Player not found');
     }
-    await this.teamRepo.delete(id);
+    await this.repo.delete(id);
+  }
+
+  async getPlayerStats(): Promise<PlayerStats[]> {
+    try {
+      const players = await this.repo.findAll();
+      const totalMatches = await this.repo.getTotalMatches();
+
+      if (!players || players.length === 0) {
+        return [];
+      }
+
+      const playerStats: PlayerStats[] = [];
+      for (const player of players) {
+        try {
+          const team = await this.repo.findTeamById(player.teamId);
+          const performances = await this.repo.getPlayerPerformances(player.id);
+          const history = await this.repo.getPlayerHistory(player.id);
+
+          const matchesPlayed = performances.length;
+          const selectedPercentage =
+            totalMatches > 0 ? (matchesPlayed / totalMatches) * 100 : 0;
+
+          const totalPerformancePoints = performances.reduce(
+            (sum, p) => sum + (p.points || 0),
+            0,
+          );
+          const rewardRate =
+            matchesPlayed > 0
+              ? (totalPerformancePoints / matchesPlayed) * 0.1
+              : 0;
+
+          const totalPoints = history.reduce(
+            (sum, h) => sum + (h.points || 0),
+            0,
+          );
+
+          playerStats.push({
+            id: player.id,
+            player_name: `${player.firstName} ${player.lastName}`,
+            player_team: team?.name || 'Unknown',
+            image_path: player.image_path,
+            selected_percentage: Number(selectedPercentage.toFixed(2)),
+            reward_rate: Number(rewardRate.toFixed(2)),
+            points: totalPoints,
+          });
+        } catch (error) {
+          console.error(
+            `Error processing player ${player.id} (${player.firstName} ${player.lastName}):`,
+            error,
+          );
+          continue;
+        }
+      }
+
+      return playerStats;
+    } catch (error) {
+      console.error('Unexpected error in getPlayerStats:', error);
+      throw error;
+    }
+  }
+
+  async getPlayerRadarStats(id: string): Promise<PlayerRadarStats> {
+    const player = await this.repo.findOne(id);
+    if (!player) {
+      throw new NotFoundException('Player not found');
+    }
+    const team = await this.repo.findTeamById(player.teamId);
+    const performances = await this.repo.getPlayerPerformances(id);
+    const history = await this.repo.getPlayerHistory(id);
+
+    const avgRuns =
+      performances.length > 0
+        ? performances.reduce((sum, p) => sum + (p.runs || 0), 0) /
+          performances.length
+        : 0;
+    const avgCatches =
+      performances.length > 0
+        ? performances.reduce((sum, p) => sum + (p.catches || 0), 0) /
+          performances.length
+        : 0;
+    const avgWickets =
+      performances.length > 0
+        ? performances.reduce((sum, p) => sum + (p.wickets || 0), 0) /
+          performances.length
+        : 0;
+    const avgHistoryRuns =
+      history.length > 0
+        ? history.reduce((sum, h) => sum + (h.runs || 0), 0) / history.length
+        : 0;
+    const avgHistoryPoints =
+      history.length > 0
+        ? history.reduce((sum, h) => sum + (h.points || 0), 0) / history.length
+        : 0;
+
+    const goals = Math.min(avgRuns * 2, 100);
+    const assists = Math.min(avgCatches * 20, 100);
+    const hitting = Math.min(avgHistoryRuns * 2, 100);
+    const speed = Math.min(avgWickets * 20, 100);
+    const dribbling = Math.min(avgHistoryPoints * 1.5, 100);
+
+    return {
+      image_path: team?.image_path || 'Unknown Team Image',
+      player_name: `${player.firstName} ${player.lastName}`,
+      stats: {
+        goals: Number(goals.toFixed(2)),
+        assists: Number(assists.toFixed(2)),
+        hitting: Number(hitting.toFixed(2)),
+        speed: Number(speed.toFixed(2)),
+        dribbling: Number(dribbling.toFixed(2)),
+      },
+    };
   }
 }

--- a/src/types/player.types.ts
+++ b/src/types/player.types.ts
@@ -1,0 +1,21 @@
+export interface PlayerStats {
+  id: string;
+  player_name: string;
+  player_team: string;
+  image_path: string;
+  selected_percentage: number;
+  reward_rate: number;
+  points: number;
+}
+
+export interface PlayerRadarStats {
+  image_path: string;
+  player_name: string;
+  stats: {
+    goals: number;
+    assists: number;
+    hitting: number;
+    speed: number;
+    dribbling: number;
+  };
+}


### PR DESCRIPTION
This PR adds two endpoints: `/cricket-player/stats` and `/cricket-player/radar/:id` to the player service. These endpoints will 
offload the calculations to the backend and return the data required for the player pools table and the player details section.

P.S: My calculations for the stats may not be accurate