### PR TITLE
Feat/Pagination, optimization and home data metrics

### DIFF
--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -1,18 +1,38 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
-import { CricketMatch, CricketPlayer, CricketPool, CricketTeam, PlayerPerformance, BetsOptions, SpecialBet, CricketPlayerHistorial } from 'src/schema';
+import {
+  CricketMatch,
+  CricketPlayer,
+  CricketPool,
+  CricketTeam,
+  PlayerPerformance,
+  BetsOptions,
+  SpecialBet,
+  CricketPlayerHistorial,
+} from 'src/schema';
 
-export const getDatabaseConfig = (configService: ConfigService): TypeOrmModuleOptions => ({
+export const getDatabaseConfig = (
+  configService: ConfigService,
+): TypeOrmModuleOptions => ({
   type: 'mariadb',
-  host: configService.get('DB_HOST') || 'localhost',
-  port: parseInt(configService.get('DB_PORT') || "1433"),
-  username: configService.get('DB_USERNAME') || 'sa',
-  password: configService.get('DB_PASSWORD') || 'admin123!',
+  host: configService.get('DB_HOST'),
+  port: parseInt(configService.get('DB_PORT') || '1433'),
+  username: configService.get('DB_USERNAME'),
+  password: configService.get('DB_PASSWORD'),
   database: configService.get('DB_DATABASE') || 'StarkFantasy',
   // options: {
   //   encrypt: false,
   //   trustServerCertificate: true,
   // },
-  entities: [CricketMatch, CricketTeam, CricketPool, PlayerPerformance, CricketPlayer, BetsOptions, SpecialBet, CricketPlayerHistorial],
+  entities: [
+    CricketMatch,
+    CricketTeam,
+    CricketPool,
+    PlayerPerformance,
+    CricketPlayer,
+    BetsOptions,
+    SpecialBet,
+    CricketPlayerHistorial,
+  ],
   synchronize: false,
 });

--- a/src/sports/modules/API/api.module.ts
+++ b/src/sports/modules/API/api.module.ts
@@ -4,10 +4,7 @@ import { SportmonksService } from './sportmonks.service';
 import { CricketTeamModule } from '../team/team.module';
 
 @Module({
-  imports: [
-    HttpModule,
-    CricketTeamModule, 
-  ],
+  imports: [HttpModule, CricketTeamModule],
   providers: [SportmonksService],
   exports: [SportmonksService],
 })

--- a/src/sports/modules/player/controllers/player.controller.ts
+++ b/src/sports/modules/player/controllers/player.controller.ts
@@ -10,9 +10,10 @@ import {
 import { CricketPlayerService } from '../service/player.service';
 import { CricketPlayer } from 'src/schema';
 import {
-  PlayerStats,
   PlayerRadarStats,
   PlayerTableViewStats,
+  PaginatedPlayerStats,
+  HomeData,
 } from 'src/types/player.types';
 
 @Controller('cricket-player')
@@ -29,17 +30,33 @@ export class CricketPlayerController {
     return this.playerService.findAll();
   }
 
+  @Get('home-data')
+  async getHomeData(): Promise<HomeData> {
+    console.log('Controller: Received request for /cricket-player/home-data');
+    return this.playerService.getHomeData();
+  }
+
   @Get('stats')
-  getPlayerStats(@Query('position') position?: string): Promise<PlayerStats[]> {
-    return this.playerService.getPlayerStats(position);
+  getPlayerStats(
+    @Query('position') position?: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 10,
+  ): Promise<PaginatedPlayerStats> {
+    return this.playerService.getPlayerStats(
+      position,
+      Number(page),
+      Number(limit),
+    );
   }
 
   @Get('radar/:id')
   getPlayerRadarStats(@Param('id') id: string): Promise<PlayerRadarStats> {
     return this.playerService.getPlayerRadarStats(id);
   }
+
   @Get('table-stats')
   getPlayerTableStats(): Promise<PlayerTableViewStats[]> {
+    console.log('Controller: Received request for /cricket-player/home-data');
     return this.playerService.getPlayerTableStats();
   }
 

--- a/src/sports/modules/player/repository/player.repository.ts
+++ b/src/sports/modules/player/repository/player.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable, ConflictException } from '@nestjs/common';
-import { Repository, FindManyOptions } from 'typeorm';
+import { Repository, FindManyOptions, MoreThan } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   CricketPlayer,
@@ -34,7 +34,26 @@ export class CricketPlayerRepository {
     return this.playerRepo.save(player);
   }
 
-  async findAll(position?: string): Promise<CricketPlayer[]> {
+  async findAll(
+    position?: string,
+    page = 1,
+    limit = 10,
+  ): Promise<[CricketPlayer[], number]> {
+    const findOptions: FindManyOptions<CricketPlayer> = {};
+
+    if (position) {
+      findOptions.where = { position: position };
+    }
+
+    // Pagination options
+    const skip = (page - 1) * limit;
+    findOptions.skip = skip;
+    findOptions.take = limit;
+
+    return this.playerRepo.findAndCount(findOptions);
+  }
+
+  async findAllPlayers(position?: string): Promise<CricketPlayer[]> {
     const findOptions: FindManyOptions<CricketPlayer> = {};
     if (position) {
       findOptions.where = { position: position };
@@ -46,11 +65,21 @@ export class CricketPlayerRepository {
     return this.playerRepo.delete(id);
   }
 
-  findOne(id: string) {
+  findOne(id: string): Promise<CricketPlayer | null> {
     return this.playerRepo.findOne({ where: { id } });
   }
 
-  async findTeamById(teamId: string) {
+  async getAllTeams(): Promise<CricketTeam[]> {
+    try {
+      const teams = await this.teamRepo.find();
+      return teams;
+    } catch (error) {
+      console.error('Error fetching all teams:', error);
+      return [];
+    }
+  }
+
+  async findTeamById(teamId: string): Promise<CricketTeam | null> {
     try {
       const team = await this.teamRepo.findOne({ where: { id: teamId } });
       return team;
@@ -60,7 +89,7 @@ export class CricketPlayerRepository {
     }
   }
 
-  async getTotalMatches() {
+  async getTotalMatches(): Promise<number> {
     try {
       const count = await this.matchRepo.count();
       return count;
@@ -70,7 +99,17 @@ export class CricketPlayerRepository {
     }
   }
 
-  async getPlayerPerformances(playerId: string) {
+  async getAllPlayerPerformances(): Promise<PlayerPerformance[]> {
+    try {
+      const performances = await this.performanceRepo.find();
+      return performances;
+    } catch (error) {
+      console.error('Error fetching all player performances:', error);
+      return [];
+    }
+  }
+
+  async getPlayerPerformances(playerId: string): Promise<PlayerPerformance[]> {
     try {
       const performances = await this.performanceRepo.find({
         where: { cricketPlayerId: playerId },
@@ -85,12 +124,41 @@ export class CricketPlayerRepository {
     }
   }
 
-  async getPlayerHistory(playerId: string) {
+  async getAllPlayerHistory(): Promise<CricketPlayerHistorial[]> {
+    try {
+      const history = await this.historyRepo.find();
+      return history;
+    } catch (error) {
+      console.error('Error fetching all player history:', error);
+      return [];
+    }
+  }
+
+  async getPlayerHistory(playerId: string): Promise<CricketPlayerHistorial[]> {
     try {
       const history = await this.historyRepo.find({ where: { playerId } });
       return history;
     } catch (error) {
       console.error(`Error fetching history for player ${playerId}:`, error);
+      return [];
+    }
+  }
+
+  async getUpcomingMatches(): Promise<CricketMatch[]> {
+    try {
+      const now = new Date();
+      const upcomingMatches = await this.matchRepo.find({
+        where: {
+          matchDate: MoreThan(now),
+        },
+        relations: ['homeTeam', 'awayTeam'],
+        order: {
+          matchDate: 'ASC',
+        },
+      });
+      return upcomingMatches;
+    } catch (error) {
+      console.error('Error fetching upcoming matches:', error);
       return [];
     }
   }

--- a/src/types/player.types.ts
+++ b/src/types/player.types.ts
@@ -1,3 +1,24 @@
+export interface Team {
+  id: string;
+  name: string;
+  image_path: string;
+}
+
+export interface Match {
+  id: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  matchDate: Date;
+  homeTeam: Team;
+  awayTeam: Team;
+  pool: any;
+}
+
+export interface HomeData {
+  topPlayers: PlayerStats[];
+  upcomingMatches: Match[];
+}
+
 export interface PlayerStats {
   id: string;
   player_name: string;
@@ -6,13 +27,15 @@ export interface PlayerStats {
   selected_percentage: number;
   reward_rate: number;
   points: number;
+  runs: number;
 }
 
 export interface PlayerRadarStats {
   image_path: string;
+  team_name: string;
   player_name: string;
   stats: {
-    goals: number;
+    runs: number;
     assists: number;
     hitting: number;
     speed: number;
@@ -32,4 +55,11 @@ export interface PlayerTableViewStats {
   totalRuns: number;
   totalWickets: number;
   minutesPlayed: number;
+}
+
+export interface PaginatedPlayerStats {
+  data: PlayerStats[];
+  total: number;
+  page: number;
+  limit: number;
 }


### PR DESCRIPTION
# Feat: Pagination, Team Info, Optimization, and Home Data  

## Description

This PR optimizes the backend player endpoints and service logic. It adds pagination to the `/cricket-player/stats` endpoint, improves data fetching in the service layer for better performance, and introduces a new endpoint `/cricket-player/home-data` that returns combined data for the application's home page, including top players by total points and upcoming matches.

### Test the Endpoints

#### Get Player Stats with Pagination (e.g., page 2, limit 5)

```bash
"http://localhost:3000/cricket-player/stats?page=2&limit=5"
```
#### Get Player Stats with Position Filter and Pagination

```bash
 "http://localhost:3000/cricket-player/stats?position=Bowler&page=1&limit=10"
```

#### Get Player Radar Stats (replace `[id]` with actual player ID, e.g., 108)

```bash
 "http://localhost:3000/cricket-player/radar/108"
```

#### Get Home Page Data

```bash
 "http://localhost:3000/cricket-player/home-data"
```

## Summary

- **Implemented pagination** for `/cricket-player/stats` endpoint
- **Optimized data fetching** using `Promise.all` and mapping
- **Added new endpoint** `/cricket-player/home-data` for home page combined data

---

## Changes Made to the Codebase

### Backend

- `src/cricket-player/player.service.ts`
  - Modified `getPlayerStats` to accept `page` and `limit` parameters and return `PaginatedPlayerStats`
  - Modified `getPlayerRadarStats` to fetch and include team name and image path
  - Implemented data fetching optimization using `Promise.all` and maps
  - Added `getHomeData` method

---