### PR TITLE
Soccer team entity

### DIFF
--- a/src/scripts/BD.sql
+++ b/src/scripts/BD.sql
@@ -4,10 +4,10 @@ Use StarkFantasy
 
 
 CREATE TABLE cricket_team (
-id VARCHAR(100) UNIQUE NOT NULL,
-name VARCHAR (200),
-image_path VARCHAR(300),
-    CONSTRAINT PK_CricketTeamID PRIMARY KEY (Id)
+  id VARCHAR(100) UNIQUE NOT NULL,
+  name VARCHAR (200),
+  image_path VARCHAR(300),
+  CONSTRAINT PK_CricketTeamID PRIMARY KEY (Id)
 )
 
 CREATE TABLE cricket_match (

--- a/src/sports/modules/team/controllers/team.controller.ts
+++ b/src/sports/modules/team/controllers/team.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Delete, Put } from '@nestjs/common';
 import { CricketTeamService } from '../service/team.service';
 import { CricketTeam } from "src/schema";
 
@@ -7,24 +7,29 @@ import { CricketTeam } from "src/schema";
 export class CricketTeamController{
     constructor (private readonly teamService: CricketTeamService){}
 
-@Post()
-create (@Body() dto: CricketTeam){
-    return this.teamService.create(dto);
-}
+    @Post()
+    async create (@Body() teamData: CricketTeam): Promise<CricketTeam> {
+        return this.teamService.create(teamData);
+    }
 
-@Get()
-findAll(){
-    return this.teamService.findAll();
-}
+    @Get()
+    async findAll(): Promise<CricketTeam[]> {
+        return this.teamService.findAll();
+    }
 
-@Get (':id')
-findOne(@Param ('id') id:string){
-    return this.teamService.findOne(id);
-}
+    @Get (':id')
+    async findOne(@Param ('id') id:string): Promise<CricketTeam | null> {
+        return this.teamService.findOne(id);
+    }
 
-@Delete (':id')
-delete (@Param('id') id:string){
-return this.teamService.delete(id);
-}
+    @Put (':id')
+    async update (@Param('id') id: string, @Body() teamData: Partial<CricketTeam>): Promise<CricketTeam> {
+        return this.teamService.update(id, teamData);
+    }
+
+    @Delete (':id')
+    async delete (@Param('id') id:string): Promise<void> {
+        return this.teamService.delete(id);
+    }
 }
 

--- a/src/sports/modules/team/repository/team.repository.ts
+++ b/src/sports/modules/team/repository/team.repository.ts
@@ -10,24 +10,34 @@ export class CricketTeamRepository {
     private readonly repo: Repository<CricketTeam>,
   ) {}
 
-  async create(team: CricketTeam) {
-    const existing = await this.repo.findOne({ where: { id: team.id } });
+  async create(teamData: CricketTeam): Promise<CricketTeam> {
+    const existing = await this.repo.findOne({ where: { id: teamData.id } });
     if (existing) {
       throw new ConflictException('The team ID already exists');
     }
 
-    return this.repo.save(team);
+    return this.repo.save(teamData);
   }
 
-  findAll() {
+  async findAll(): Promise<CricketTeam[]> {
     return this.repo.find();
   }
 
-  findOne(id: string) {
+  async findOne(id: string): Promise<CricketTeam | null> {
     return this.repo.findOne({ where: { id } });
   }
 
-  delete(id: string) {
-    return this.repo.delete(id);
+  async update(id: string, teamData: Partial<CricketTeam>): Promise<CricketTeam> {
+    const existing = await this.repo.findOne({ where: { id } });
+    if (!existing) {
+      throw new ConflictException('The team ID does not exist');
+    }
+
+    Object.assign(existing, teamData);
+    return this.repo.save(existing);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.delete(id);
   }
 }

--- a/src/sports/modules/team/service/team.service.ts
+++ b/src/sports/modules/team/service/team.service.ts
@@ -6,8 +6,8 @@ import { CricketTeam } from 'src/schema';
 export class CricketTeamService {
   constructor(private readonly teamRepo: CricketTeamRepository) {}
 
-  async create(entity: CricketTeam) {
-    const team = new CricketTeam(entity.id, entity.name,entity.image_path);
+  async create(teamData: CricketTeam) {
+    const team = new CricketTeam(teamData.id, teamData.name, teamData.image_path);
     try {
       return await this.teamRepo.create(team);
     } catch (error) {
@@ -18,17 +18,34 @@ export class CricketTeamService {
     }
   }
 
-  findAll() {
+  async findAll(): Promise<CricketTeam[]> {
     return this.teamRepo.findAll();
   }
 
-  async findOne(id: string) {
+  async findOne(id: string): Promise<CricketTeam | null> {
     const team = await this.teamRepo.findOne(id);
     if (!team) {
       throw new NotFoundException('Team not found');
     }
     return team;
   }
+
+  async update(id: string, teamData: Partial<CricketTeam>): Promise<CricketTeam> {
+    const existingTeam = await this.teamRepo.findOne(id);
+    if (!existingTeam) {
+      throw new NotFoundException('Team not found');
+    }
+    const updatedTeam = Object.assign(existingTeam, teamData);
+    try {
+      return await this.teamRepo.update(id, updatedTeam);
+    } catch (error) {
+      if (error.code === '23505' || error.number === 2627) {
+        throw new ConflictException('The team ID already exists');
+      }
+      throw error;
+    }
+  }
+
 
   async delete(id: string): Promise<void> {
     const team = await this.teamRepo.findOne(id);


### PR DESCRIPTION
I've implemented the Soccer team entity with all the necessary requirement following the same structure as the cricket.

Closes #15 

CRUD Endpoint:
- Create team: POST /cricket-team
![create team](https://github.com/user-attachments/assets/33bcaac2-51a1-48e5-b642-b25b0620bc56)

- Get All teams: GET /cricket-team
![get all team](https://github.com/user-attachments/assets/2e296993-6d85-4bcb-a7bb-c6389ee8769a)

- Get a team: GET /cricket-team/:id
![get a team](https://github.com/user-attachments/assets/bad28864-46df-4076-8518-88b9b09b4057)

- Update team: PUT /cricket-team/:id
![update team](https://github.com/user-attachments/assets/c42fdb57-f58f-4e85-a009-a0a000858478)

- Delete team: DELETE /cricket-team/:id
![delete team](https://github.com/user-attachments/assets/1ecedb3b-9d49-4cf5-b946-732e02fc62aa)
